### PR TITLE
set includeOriginalStrings to false

### DIFF
--- a/download_file_request.go
+++ b/download_file_request.go
@@ -55,6 +55,8 @@ func (request FileDownloadRequest) GetQuery() url.Values {
 
 	if request.IncludeOriginal {
 		query.Set("includeOriginalStrings", "true")
+	}else{
+		query.Set("includeOriginalStrings", "false")
 	}
 
 	return query


### PR DESCRIPTION
includeOriginalStrings by default will be set to true in the rest api def (although the doc didn't mention the default value)
so it will never be set to false unless we set it explicitly here to false
