### PR TITLE
Rps 10123 glossary export import

### DIFF
--- a/api/glossary/ent_glossary_create.go
+++ b/api/glossary/ent_glossary_create.go
@@ -1,0 +1,55 @@
+package glossary
+
+import "time"
+
+// CreateGlossaryRequest is the JSON body for a glossary-create call.
+type CreateGlossaryRequest struct {
+	GlossaryName     string           `json:"glossaryName"`
+	Description      string           `json:"description"`
+	VerificationMode bool             `json:"verificationMode"`
+	LocaleIDs        []string         `json:"localeIds"`
+	FallbackLocales  []FallbackLocale `json:"fallbackLocales"`
+}
+
+type FallbackLocale struct {
+	FallbackLocaleID string   `json:"fallbackLocaleId"`
+	LocaleIDs        []string `json:"localeIds"`
+}
+
+// CreateGlossaryResponse is the public result of a glossary-create call.
+type CreateGlossaryResponse struct {
+	Code         int
+	GlossaryUID  string
+	AccountUID   string
+	GlossaryName string
+}
+
+// createGlossaryResponse holds the raw JSON envelope returned by the API.
+type createGlossaryResponse struct {
+	Response struct {
+		Code string `json:"code"`
+		Data struct {
+			GlossaryUID       string           `json:"glossaryUid"`
+			AccountUID        string           `json:"accountUid"`
+			GlossaryName      string           `json:"glossaryName"`
+			Description       string           `json:"description"`
+			VerificationMode  bool             `json:"verificationMode"`
+			Archived          bool             `json:"archived"`
+			CreatedByUserUID  string           `json:"createdByUserUid"`
+			ModifiedByUserUID string           `json:"modifiedByUserUid"`
+			CreatedDate       time.Time        `json:"createdDate"`
+			ModifiedDate      time.Time        `json:"modifiedDate"`
+			LocaleIDs         []string         `json:"localeIds"`
+			FallbackLocales   []FallbackLocale `json:"fallbackLocales"`
+		} `json:"data"`
+	} `json:"response"`
+}
+
+func toCreateGlossaryResponse(g createGlossaryResponse, code int) CreateGlossaryResponse {
+	return CreateGlossaryResponse{
+		Code:         code,
+		GlossaryUID:  g.Response.Data.GlossaryUID,
+		AccountUID:   g.Response.Data.AccountUID,
+		GlossaryName: g.Response.Data.GlossaryName,
+	}
+}

--- a/api/glossary/ent_glossary_export.go
+++ b/api/glossary/ent_glossary_export.go
@@ -1,0 +1,68 @@
+package glossary
+
+import (
+	"io"
+	"time"
+)
+
+type ExportGlossaryRequest struct {
+	Format        string               `json:"format"`
+	TbxVersion    string               `json:"tbxVersion,omitempty"`
+	Filter        ExportGlossaryFilter `json:"filter"`
+	FocusLocaleId string               `json:"focusLocaleId,omitempty"`
+	LocaleIds     []string             `json:"localeIds"`
+	SkipEntries   bool                 `json:"skipEntries,omitempty"`
+}
+
+type ExportGlossaryFilter struct {
+	Query                      string                      `json:"query,omitempty"`
+	LocaleIds                  []string                    `json:"localeIds,omitempty"`
+	EntryUids                  []string                    `json:"entryUids,omitempty"`
+	EntryState                 string                      `json:"entryState,omitempty"`
+	MissingTranslationLocaleId string                      `json:"missingTranslationLocaleId,omitempty"`
+	PresentTranslationLocaleId string                      `json:"presentTranslationLocaleId,omitempty"`
+	DntLocaleId                string                      `json:"dntLocaleId,omitempty"`
+	ReturnFallbackTranslations bool                        `json:"returnFallbackTranslations,omitempty"`
+	Labels                     *ExportGlossaryLabelsFilter `json:"labels,omitempty"`
+	DntTermSet                 bool                        `json:"dntTermSet,omitempty"`
+	Created                    *ExportGlossaryDateFilter   `json:"created,omitempty"`
+	LastModified               *ExportGlossaryDateFilter   `json:"lastModified,omitempty"`
+	CreatedBy                  *ExportGlossaryUserFilter   `json:"createdBy,omitempty"`
+	LastModifiedBy             *ExportGlossaryUserFilter   `json:"lastModifiedBy,omitempty"`
+	Paging                     ExportGlossaryPaging        `json:"paging"`
+	Sorting                    *ExportGlossarySorting      `json:"sorting,omitempty"`
+}
+
+type ExportGlossaryLabelsFilter struct {
+	Type string `json:"type,omitempty"`
+}
+
+type ExportGlossaryDateFilter struct {
+	Level string    `json:"level,omitempty"`
+	Date  time.Time `json:"date"`
+	Type  string    `json:"type,omitempty"`
+}
+
+type ExportGlossaryUserFilter struct {
+	Level   string   `json:"level,omitempty"`
+	UserIds []string `json:"userIds,omitempty"`
+}
+
+type ExportGlossaryPaging struct {
+	Offset int `json:"offset"`
+	Limit  int `json:"limit"`
+}
+
+type ExportGlossarySorting struct {
+	Field     string `json:"field,omitempty"`
+	Direction string `json:"direction,omitempty"`
+	LocaleId  string `json:"localeId,omitempty"`
+}
+
+type ExportGlossaryResponse struct {
+	Code          int
+	Filename      string
+	ContentType   string
+	ContentLength int64
+	Data          io.ReadCloser
+}

--- a/api/glossary/ent_glossary_import.go
+++ b/api/glossary/ent_glossary_import.go
@@ -1,0 +1,95 @@
+package glossary
+
+type ImportGlossaryRequest struct {
+	File        []byte
+	FileName    string
+	MediaType   string
+	ArchiveMode bool
+}
+
+type ImportGlossaryResponse struct {
+	Code               int
+	GlossaryUID        string
+	ImportUID          string
+	ImportStatus       string
+	EntryChanges       ImportEntryChanges
+	TranslationChanges []ImportTranslationChanges
+	Warnings           []ImportWarning
+}
+
+type ImportEntryChanges struct {
+	NewEntries           int
+	ExistingEntryUpdates int
+	NotMatchedEntries    int
+	EntriesToArchive     int
+}
+
+type ImportTranslationChanges struct {
+	LocaleID             string
+	NewTranslations      int
+	UpdatedTranslations  int
+	TranslationsToRemove int
+}
+
+type ImportWarning struct {
+	Key     string
+	Message string
+}
+
+func toImportGlossaryResponse(r importGlossary, code int) ImportGlossaryResponse {
+	res := ImportGlossaryResponse{
+		Code:         code,
+		GlossaryUID:  r.Response.Data.GlossaryImport.GlossaryUid,
+		ImportUID:    r.Response.Data.GlossaryImport.ImportUid,
+		ImportStatus: r.Response.Data.GlossaryImport.ImportStatus,
+		EntryChanges: ImportEntryChanges{
+			NewEntries:           r.Response.Data.EntryChanges.NewEntries,
+			ExistingEntryUpdates: r.Response.Data.EntryChanges.ExistingEntryUpdates,
+			NotMatchedEntries:    r.Response.Data.EntryChanges.NotMatchedEntries,
+			EntriesToArchive:     r.Response.Data.EntryChanges.EntriesToArchive,
+		},
+	}
+	res.TranslationChanges = make([]ImportTranslationChanges, 0, len(r.Response.Data.TranslationChanges))
+	for i, t := range r.Response.Data.TranslationChanges {
+		res.TranslationChanges[i] = ImportTranslationChanges{
+			LocaleID:             t.LocaleId,
+			NewTranslations:      t.NewTranslations,
+			UpdatedTranslations:  t.UpdatedTranslations,
+			TranslationsToRemove: t.TranslationsToRemove,
+		}
+	}
+	res.Warnings = make([]ImportWarning, 0, len(r.Response.Data.Warnings))
+	for i, w := range r.Response.Data.Warnings {
+		res.Warnings[i] = ImportWarning{Key: w.Key, Message: w.Message}
+	}
+	return res
+}
+
+type importGlossary struct {
+	Response struct {
+		Code string `json:"code"`
+		Data struct {
+			GlossaryImport struct {
+				GlossaryUid  string `json:"glossaryUid"`
+				ImportUid    string `json:"importUid"`
+				ImportStatus string `json:"importStatus"`
+			} `json:"glossaryImport"`
+			EntryChanges struct {
+				NewEntries           int `json:"newEntries"`
+				ExistingEntryUpdates int `json:"existingEntryUpdates"`
+				NotMatchedEntries    int `json:"notMatchedEntries"`
+				EntriesToArchive     int `json:"entriesToArchive"`
+			} `json:"entryChanges"`
+			TranslationChanges []struct {
+				LocaleId             string `json:"localeId"`
+				NewTranslations      int    `json:"newTranslations"`
+				UpdatedTranslations  int    `json:"updatedTranslations"`
+				TranslationsToRemove int    `json:"translationsToRemove"`
+			} `json:"translationChanges"`
+			Warnings []struct {
+				Key     string `json:"key"`
+				Message string `json:"message"`
+			} `json:"warnings"`
+		} `json:"data"`
+	} `json:"response"`
+}

--- a/api/glossary/ent_glossary_import.go
+++ b/api/glossary/ent_glossary_import.go
@@ -49,7 +49,7 @@ func toImportGlossaryResponse(r importGlossary, code int) ImportGlossaryResponse
 			EntriesToArchive:     r.Response.Data.EntryChanges.EntriesToArchive,
 		},
 	}
-	res.TranslationChanges = make([]ImportTranslationChanges, 0, len(r.Response.Data.TranslationChanges))
+	res.TranslationChanges = make([]ImportTranslationChanges, len(r.Response.Data.TranslationChanges))
 	for i, t := range r.Response.Data.TranslationChanges {
 		res.TranslationChanges[i] = ImportTranslationChanges{
 			LocaleID:             t.LocaleId,
@@ -58,7 +58,7 @@ func toImportGlossaryResponse(r importGlossary, code int) ImportGlossaryResponse
 			TranslationsToRemove: t.TranslationsToRemove,
 		}
 	}
-	res.Warnings = make([]ImportWarning, 0, len(r.Response.Data.Warnings))
+	res.Warnings = make([]ImportWarning, len(r.Response.Data.Warnings))
 	for i, w := range r.Response.Data.Warnings {
 		res.Warnings[i] = ImportWarning{Key: w.Key, Message: w.Message}
 	}

--- a/api/glossary/ent_glossary_import_status.go
+++ b/api/glossary/ent_glossary_import_status.go
@@ -1,0 +1,28 @@
+package glossary
+
+type ImportStatusResponse struct {
+	Code         int
+	GlossaryUID  string
+	ImportUID    string
+	ImportStatus string
+}
+
+func toImportStatusResponse(r importStatusResponse, code int) ImportStatusResponse {
+	return ImportStatusResponse{
+		Code:         code,
+		GlossaryUID:  r.Response.Data.GlossaryUID,
+		ImportUID:    r.Response.Data.ImportUID,
+		ImportStatus: r.Response.Data.ImportStatus,
+	}
+}
+
+type importStatusResponse struct {
+	Response struct {
+		Code string `json:"code"`
+		Data struct {
+			GlossaryUID  string `json:"glossaryUid"`
+			ImportUID    string `json:"importUid"`
+			ImportStatus string `json:"importStatus"`
+		} `json:"data"`
+	} `json:"response"`
+}

--- a/api/glossary/ent_glossary_read.go
+++ b/api/glossary/ent_glossary_read.go
@@ -28,7 +28,7 @@ type readGlossaryResponseRow struct {
 }
 
 func toReadGlossaryResponses(r readGlossaryResponse) []ReadGlossaryResponse {
-	res := make([]ReadGlossaryResponse, 0, len(r.Response.Data.Items))
+	res := make([]ReadGlossaryResponse, len(r.Response.Data.Items))
 	for i, item := range r.Response.Data.Items {
 		res[i] = ReadGlossaryResponse{
 			GlossaryUid: item.GlossaryUid,

--- a/api/glossary/ent_glossary_read.go
+++ b/api/glossary/ent_glossary_read.go
@@ -1,0 +1,41 @@
+package glossary
+
+// ReadGlossaryResponse is the public representation of a single glossary
+// returned by the list/search endpoint.
+type ReadGlossaryResponse struct {
+	GlossaryUid string
+	Name        string
+	Description string
+	LocaleIDs   []string
+}
+
+// readGlossaryResponse is the raw envelope returned by the list/search endpoint.
+type readGlossaryResponse struct {
+	Response struct {
+		Code string `json:"code"`
+		Data struct {
+			TotalCount int                       `json:"totalCount"`
+			Items      []readGlossaryResponseRow `json:"items"`
+		} `json:"data"`
+	} `json:"response"`
+}
+
+type readGlossaryResponseRow struct {
+	GlossaryUid  string   `json:"glossaryUid"`
+	GlossaryName string   `json:"glossaryName"`
+	Description  string   `json:"description"`
+	LocaleIDs    []string `json:"localeIds"`
+}
+
+func toReadGlossaryResponses(r readGlossaryResponse) []ReadGlossaryResponse {
+	res := make([]ReadGlossaryResponse, 0, len(r.Response.Data.Items))
+	for i, item := range r.Response.Data.Items {
+		res[i] = ReadGlossaryResponse{
+			GlossaryUid: item.GlossaryUid,
+			Name:        item.GlossaryName,
+			Description: item.Description,
+			LocaleIDs:   item.LocaleIDs,
+		}
+	}
+	return res
+}

--- a/api/glossary/ent_glossary_read.go
+++ b/api/glossary/ent_glossary_read.go
@@ -1,41 +1,53 @@
 package glossary
 
-// ReadGlossaryResponse is the public representation of a single glossary
-// returned by the list/search endpoint.
-type ReadGlossaryResponse struct {
-	GlossaryUid string
+// GetGlossaryResponse is the public representation of a single glossary.
+type GetGlossaryResponse struct {
+	GlossaryUID string
 	Name        string
 	Description string
 	LocaleIDs   []string
 }
 
-// readGlossaryResponse is the raw envelope returned by the list/search endpoint.
-type readGlossaryResponse struct {
+// getGlossaryResponse is the raw envelope returned by the single-glossary
+// read endpoint (GET .../glossaries/{glossaryUid}); data is the glossary object.
+type getGlossaryResponse struct {
+	Response struct {
+		Code string                  `json:"code"`
+		Data getGlossaryDataResponse `json:"data"`
+	} `json:"response"`
+}
+
+// getGlossariesResponse is the raw envelope returned by the list/search endpoint.
+type getGlossariesResponse struct {
 	Response struct {
 		Code string `json:"code"`
 		Data struct {
 			TotalCount int                       `json:"totalCount"`
-			Items      []readGlossaryResponseRow `json:"items"`
+			Items      []getGlossaryDataResponse `json:"items"`
 		} `json:"data"`
 	} `json:"response"`
 }
 
-type readGlossaryResponseRow struct {
+type getGlossaryDataResponse struct {
 	GlossaryUid  string   `json:"glossaryUid"`
 	GlossaryName string   `json:"glossaryName"`
 	Description  string   `json:"description"`
 	LocaleIDs    []string `json:"localeIds"`
 }
 
-func toReadGlossaryResponses(r readGlossaryResponse) []ReadGlossaryResponse {
-	res := make([]ReadGlossaryResponse, len(r.Response.Data.Items))
+func toGetGlossaryResponse(row getGlossaryDataResponse) GetGlossaryResponse {
+	return GetGlossaryResponse{
+		GlossaryUID: row.GlossaryUid,
+		Name:        row.GlossaryName,
+		Description: row.Description,
+		LocaleIDs:   row.LocaleIDs,
+	}
+}
+
+func toReadGlossariesResponse(r getGlossariesResponse) []GetGlossaryResponse {
+	res := make([]GetGlossaryResponse, len(r.Response.Data.Items))
 	for i, item := range r.Response.Data.Items {
-		res[i] = ReadGlossaryResponse{
-			GlossaryUid: item.GlossaryUid,
-			Name:        item.GlossaryName,
-			Description: item.Description,
-			LocaleIDs:   item.LocaleIDs,
-		}
+		res[i] = toGetGlossaryResponse(item)
 	}
 	return res
 }

--- a/api/glossary/glossary.go
+++ b/api/glossary/glossary.go
@@ -1,0 +1,41 @@
+package glossary
+
+import (
+	"context"
+	"errors"
+
+	smclient "github.com/Smartling/api-sdk-go/helpers/sm_client"
+	"github.com/Smartling/api-sdk-go/helpers/uid"
+)
+
+const glossaryBasePath = "/glossary-api/v3/accounts/"
+
+var (
+	ErrGlossaryNotFound = errors.New("glossary not found")
+	ErrImportNotFound   = errors.New("glossary import not found")
+)
+
+// Glossary defines the glossary behaviour
+type Glossary interface {
+	Get(ctx context.Context, accountUID, glossaryUID string) (ReadGlossaryResponse, error)
+	GetByName(ctx context.Context, accountUID, name string) (glossaries []ReadGlossaryResponse, err error)
+	Import(ctx context.Context, accountUID uid.AccountUID, glossaryUID string, req ImportGlossaryRequest) (ImportGlossaryResponse, error)
+	ImportStatus(ctx context.Context, accountUID uid.AccountUID, glossaryUID, importUID string) (ImportStatusResponse, error)
+	ImportConfirm(ctx context.Context, accountUID uid.AccountUID, glossaryUID, importUID string) (bool, error)
+	Export(ctx context.Context, accountUID uid.AccountUID, glossaryUID string, req ExportGlossaryRequest) (ExportGlossaryResponse, error)
+	Create(ctx context.Context, accountUID uid.AccountUID, req CreateGlossaryRequest) (CreateGlossaryResponse, error)
+}
+
+// NewGlossary returns new Glossary implementation
+func NewGlossary(client *smclient.Client) Glossary {
+	return newHttpGlossary(client)
+}
+
+// httpGlossary implements Glossary interface using HTTP client
+type httpGlossary struct {
+	client *smclient.Client
+}
+
+func newHttpGlossary(client *smclient.Client) httpGlossary {
+	return httpGlossary{client: client}
+}

--- a/api/glossary/glossary.go
+++ b/api/glossary/glossary.go
@@ -17,8 +17,8 @@ var (
 
 // Glossary defines the glossary behaviour
 type Glossary interface {
-	Get(ctx context.Context, accountUID, glossaryUID string) (ReadGlossaryResponse, error)
-	GetByName(ctx context.Context, accountUID, name string) (glossaries []ReadGlossaryResponse, err error)
+	Get(ctx context.Context, accountUID uid.AccountUID, glossaryUID string) (GetGlossaryResponse, error)
+	GetByName(ctx context.Context, accountUID uid.AccountUID, name string) (glossaries []GetGlossaryResponse, err error)
 	Import(ctx context.Context, accountUID uid.AccountUID, glossaryUID string, req ImportGlossaryRequest) (ImportGlossaryResponse, error)
 	ImportStatus(ctx context.Context, accountUID uid.AccountUID, glossaryUID, importUID string) (ImportStatusResponse, error)
 	ImportConfirm(ctx context.Context, accountUID uid.AccountUID, glossaryUID, importUID string) (bool, error)

--- a/api/glossary/glossary_create.go
+++ b/api/glossary/glossary_create.go
@@ -1,0 +1,30 @@
+package glossary
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+
+	"github.com/Smartling/api-sdk-go/helpers/uid"
+)
+
+// Create creates a new glossary under the given account.
+// Endpoint: POST /glossary-api/v3/accounts/{accountUid}/glossaries.
+func (h httpGlossary) Create(ctx context.Context, accountUID uid.AccountUID, req CreateGlossaryRequest) (CreateGlossaryResponse, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return CreateGlossaryResponse{}, fmt.Errorf("marshal create glossary request: %w", err)
+	}
+
+	reqURL := path.Join(glossaryBasePath, url.PathEscape(string(accountUID)), "glossaries")
+
+	var response createGlossaryResponse
+	_, code, err := h.client.PostJSON(ctx, reqURL, payload, &response.Response.Data)
+	if err != nil {
+		return CreateGlossaryResponse{}, fmt.Errorf("failed to create glossary: %w", err)
+	}
+
+	return toCreateGlossaryResponse(response, code), nil
+}

--- a/api/glossary/glossary_export.go
+++ b/api/glossary/glossary_export.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
@@ -23,7 +24,7 @@ func (h httpGlossary) Export(ctx context.Context,
 		return ExportGlossaryResponse{}, fmt.Errorf("failed to marshal export request: %w", err)
 	}
 
-	reqURL := path.Join(glossaryBasePath, string(accountUID), "glossaries", glossaryUID, "entries", "download")
+	reqURL := path.Join(glossaryBasePath, url.PathEscape(string(accountUID)), "glossaries", url.PathEscape(glossaryUID), "entries", "download")
 
 	reply, err := h.client.Post(ctx, reqURL, payload)
 	if err != nil {

--- a/api/glossary/glossary_export.go
+++ b/api/glossary/glossary_export.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"mime"
 	"net/http"
 	"path"
@@ -33,17 +32,17 @@ func (h httpGlossary) Export(ctx context.Context,
 
 	if reply.StatusCode == http.StatusNotFound {
 		if err := reply.Body.Close(); err != nil {
-			log.Printf("failed to close response body: %v", err)
+			h.client.Logger.Infof("failed to close response body: %v", err)
 		}
 		return ExportGlossaryResponse{}, ErrGlossaryNotFound
 	}
 	if reply.StatusCode != http.StatusOK {
 		body, err := io.ReadAll(reply.Body)
 		if err != nil {
-			log.Printf("failed to read response body: %v", err)
+			h.client.Logger.Infof("failed to read response body: %v", err)
 		}
 		if err := reply.Body.Close(); err != nil {
-			log.Printf("failed to close response body: %v", err)
+			h.client.Logger.Infof("failed to close response body: %v", err)
 		}
 		return ExportGlossaryResponse{}, fmt.Errorf(
 			"failed to export glossary: unexpected response code %d: %s",
@@ -55,10 +54,10 @@ func (h httpGlossary) Export(ctx context.Context,
 	if strings.HasPrefix(contentType, "application/json") {
 		body, err := io.ReadAll(reply.Body)
 		if err != nil {
-			log.Printf("failed to read response body: %v", err)
+			h.client.Logger.Infof("failed to read response body: %v", err)
 		}
 		if err := reply.Body.Close(); err != nil {
-			log.Printf("failed to close response body: %v", err)
+			h.client.Logger.Infof("failed to close response body: %v", err)
 		}
 		return ExportGlossaryResponse{}, fmt.Errorf(
 			"failed to export glossary: server returned JSON instead of file: %s",

--- a/api/glossary/glossary_export.go
+++ b/api/glossary/glossary_export.go
@@ -1,0 +1,94 @@
+package glossary
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"mime"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/Smartling/api-sdk-go/helpers/uid"
+)
+
+// Export downloads a glossary as a binary file (TBX/CSV/XLSX, etc.).
+// The format is determined by req.Format. On success the response Data is the
+// open HTTP response body - the caller MUST Close it.
+func (h httpGlossary) Export(ctx context.Context,
+	accountUID uid.AccountUID, glossaryUID string, req ExportGlossaryRequest) (ExportGlossaryResponse, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return ExportGlossaryResponse{}, fmt.Errorf("failed to marshal export request: %w", err)
+	}
+
+	reqURL := path.Join(glossaryBasePath, string(accountUID), "glossaries", glossaryUID, "entries", "download")
+
+	reply, err := h.client.Post(ctx, reqURL, payload)
+	if err != nil {
+		return ExportGlossaryResponse{}, fmt.Errorf("failed to export glossary: %w", err)
+	}
+
+	if reply.StatusCode == http.StatusNotFound {
+		if err := reply.Body.Close(); err != nil {
+			log.Printf("failed to close response body: %v", err)
+		}
+		return ExportGlossaryResponse{}, ErrGlossaryNotFound
+	}
+	if reply.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(reply.Body)
+		if err != nil {
+			log.Printf("failed to read response body: %v", err)
+		}
+		if err := reply.Body.Close(); err != nil {
+			log.Printf("failed to close response body: %v", err)
+		}
+		return ExportGlossaryResponse{}, fmt.Errorf(
+			"failed to export glossary: unexpected response code %d: %s",
+			reply.StatusCode, body,
+		)
+	}
+
+	contentType := reply.Header.Get("Content-Type")
+	if strings.HasPrefix(contentType, "application/json") {
+		body, err := io.ReadAll(reply.Body)
+		if err != nil {
+			log.Printf("failed to read response body: %v", err)
+		}
+		if err := reply.Body.Close(); err != nil {
+			log.Printf("failed to close response body: %v", err)
+		}
+		return ExportGlossaryResponse{}, fmt.Errorf(
+			"failed to export glossary: server returned JSON instead of file: %s",
+			body,
+		)
+	}
+
+	h.client.Logger.Debugf(
+		"export response headers: Content-Type=%q Content-Length=%d Content-Disposition=%q Location=%q",
+		contentType,
+		reply.ContentLength,
+		reply.Header.Get("Content-Disposition"),
+		reply.Header.Get("Location"),
+	)
+
+	return ExportGlossaryResponse{
+		Code:          reply.StatusCode,
+		Filename:      filenameFromContentDisposition(reply.Header.Get("Content-Disposition")),
+		ContentType:   contentType,
+		ContentLength: reply.ContentLength,
+		Data:          reply.Body,
+	}, nil
+}
+
+func filenameFromContentDisposition(header string) string {
+	if header == "" {
+		return ""
+	}
+	if _, params, err := mime.ParseMediaType(header); err == nil {
+		return params["filename"]
+	}
+	return ""
+}

--- a/api/glossary/glossary_get.go
+++ b/api/glossary/glossary_get.go
@@ -1,0 +1,61 @@
+package glossary
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+// Get fetches a single glossary by its UID.
+// Endpoint: GET /glossary-api/v3/accounts/{accountUid}/glossaries/{glossaryUid}.
+func (h httpGlossary) Get(ctx context.Context, accountUID, glossaryUID string) (ReadGlossaryResponse, error) {
+	reqURL := path.Join(glossaryBasePath, url.PathEscape(accountUID), "glossaries", url.PathEscape(glossaryUID))
+
+	var row readGlossaryResponseRow
+	_, code, err := h.client.GetJSON(ctx, reqURL, nil, &row)
+	if err != nil && code == http.StatusNotFound {
+		return ReadGlossaryResponse{}, ErrGlossaryNotFound
+	}
+	if err != nil {
+		return ReadGlossaryResponse{}, fmt.Errorf("failed to get glossary: %w", err)
+	}
+
+	return ReadGlossaryResponse{
+		GlossaryUid: row.GlossaryUid,
+		Name:        row.GlossaryName,
+		Description: row.Description,
+		LocaleIDs:   row.LocaleIDs,
+	}, nil
+}
+
+// GetByName lists glossaries for the given account, optionally filtered by name.
+// Endpoint: POST /glossary-api/v3/accounts/{accountUid}/glossaries/search.
+// The Smartling Glossary API exposes listing as a search call: the filter is
+// sent in the JSON body rather than as query parameters. An empty name means
+// "no name filter" and returns all glossaries.
+func (h httpGlossary) GetByName(ctx context.Context, accountUID, name string) ([]ReadGlossaryResponse, error) {
+	body := struct {
+		Query string `json:"query,omitempty"`
+	}{Query: name}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal glossary search request: %w", err)
+	}
+
+	reqURL := path.Join(glossaryBasePath, url.PathEscape(accountUID), "glossaries", "search")
+
+	var res readGlossaryResponse
+	_, code, err := h.client.PostJSON(ctx, reqURL, payload, &res.Response.Data)
+	if err != nil && code == http.StatusNotFound {
+		return nil, ErrGlossaryNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list glossaries: %w", err)
+	}
+
+	return toReadGlossaryResponses(res), nil
+}

--- a/api/glossary/glossary_get.go
+++ b/api/glossary/glossary_get.go
@@ -7,28 +7,25 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+
+	"github.com/Smartling/api-sdk-go/helpers/uid"
 )
 
 // Get fetches a single glossary by its UID.
 // Endpoint: GET /glossary-api/v3/accounts/{accountUid}/glossaries/{glossaryUid}.
-func (h httpGlossary) Get(ctx context.Context, accountUID, glossaryUID string) (ReadGlossaryResponse, error) {
-	reqURL := path.Join(glossaryBasePath, url.PathEscape(accountUID), "glossaries", url.PathEscape(glossaryUID))
+func (h httpGlossary) Get(ctx context.Context, accountUID uid.AccountUID, glossaryUID string) (GetGlossaryResponse, error) {
+	reqURL := path.Join(glossaryBasePath, url.PathEscape(string(accountUID)), "glossaries", url.PathEscape(glossaryUID))
 
-	var row readGlossaryResponseRow
-	_, code, err := h.client.GetJSON(ctx, reqURL, nil, &row)
+	var response getGlossaryResponse
+	_, code, err := h.client.GetJSON(ctx, reqURL, nil, &response.Response.Data)
 	if err != nil && code == http.StatusNotFound {
-		return ReadGlossaryResponse{}, ErrGlossaryNotFound
+		return GetGlossaryResponse{}, ErrGlossaryNotFound
 	}
 	if err != nil {
-		return ReadGlossaryResponse{}, fmt.Errorf("failed to get glossary: %w", err)
+		return GetGlossaryResponse{}, fmt.Errorf("failed to get glossary: %w", err)
 	}
 
-	return ReadGlossaryResponse{
-		GlossaryUid: row.GlossaryUid,
-		Name:        row.GlossaryName,
-		Description: row.Description,
-		LocaleIDs:   row.LocaleIDs,
-	}, nil
+	return toGetGlossaryResponse(response.Response.Data), nil
 }
 
 // GetByName lists glossaries for the given account, optionally filtered by name.
@@ -36,7 +33,7 @@ func (h httpGlossary) Get(ctx context.Context, accountUID, glossaryUID string) (
 // The Smartling Glossary API exposes listing as a search call: the filter is
 // sent in the JSON body rather than as query parameters. An empty name means
 // "no name filter" and returns all glossaries.
-func (h httpGlossary) GetByName(ctx context.Context, accountUID, name string) ([]ReadGlossaryResponse, error) {
+func (h httpGlossary) GetByName(ctx context.Context, accountUID uid.AccountUID, name string) ([]GetGlossaryResponse, error) {
 	body := struct {
 		Query string `json:"query,omitempty"`
 	}{Query: name}
@@ -46,9 +43,9 @@ func (h httpGlossary) GetByName(ctx context.Context, accountUID, name string) ([
 		return nil, fmt.Errorf("marshal glossary search request: %w", err)
 	}
 
-	reqURL := path.Join(glossaryBasePath, url.PathEscape(accountUID), "glossaries", "search")
+	reqURL := path.Join(glossaryBasePath, url.PathEscape(string(accountUID)), "glossaries", "search")
 
-	var res readGlossaryResponse
+	var res getGlossariesResponse
 	_, code, err := h.client.PostJSON(ctx, reqURL, payload, &res.Response.Data)
 	if err != nil && code == http.StatusNotFound {
 		return nil, ErrGlossaryNotFound
@@ -57,5 +54,5 @@ func (h httpGlossary) GetByName(ctx context.Context, accountUID, name string) ([
 		return nil, fmt.Errorf("failed to list glossaries: %w", err)
 	}
 
-	return toReadGlossaryResponses(res), nil
+	return toReadGlossariesResponse(res), nil
 }

--- a/api/glossary/glossary_import.go
+++ b/api/glossary/glossary_import.go
@@ -1,0 +1,121 @@
+package glossary
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+
+	smclient "github.com/Smartling/api-sdk-go/helpers/sm_client"
+	"github.com/Smartling/api-sdk-go/helpers/uid"
+)
+
+const (
+	PendingImportStatus    = "PENDING"
+	InProgressImportStatus = "IN_PROGRESS"
+	SuccessfulImportStatus = "SUCCESSFUL"
+	FailedImportStatus     = "FAILED"
+)
+
+// Import uploads a glossary file to the given glossary as a multipart request.
+// Endpoint: POST /glossary-api/v3/accounts/{accountUid}/glossaries/{glossaryUid}/import.
+func (h httpGlossary) Import(ctx context.Context,
+	accountUID uid.AccountUID, glossaryUID string, req ImportGlossaryRequest) (ImportGlossaryResponse, error) {
+	body, contentType, err := buildImportForm(req)
+	if err != nil {
+		return ImportGlossaryResponse{}, fmt.Errorf("failed to build import form: %w", err)
+	}
+
+	reqURL := path.Join(glossaryBasePath, url.PathEscape(string(accountUID)), "glossaries", url.PathEscape(glossaryUID), "import")
+
+	var response importGlossary
+	_, code, err := h.client.PostJSON(
+		ctx,
+		reqURL,
+		body,
+		&response.Response.Data,
+		smclient.ContentTypeOption(contentType),
+	)
+	if err != nil && code == http.StatusNotFound {
+		return ImportGlossaryResponse{}, ErrGlossaryNotFound
+	}
+	if err != nil {
+		return ImportGlossaryResponse{}, fmt.Errorf("failed to import glossary: %w", err)
+	}
+
+	return toImportGlossaryResponse(response, code), nil
+}
+
+// ImportStatus polls the status of a previously submitted glossary import.
+// Endpoint: GET /glossary-api/v3/accounts/{accountUid}/glossaries/{glossaryUid}/imports/{importUid}.
+func (h httpGlossary) ImportStatus(ctx context.Context, accountUID uid.AccountUID, glossaryUID, importUID string) (ImportStatusResponse, error) {
+	reqURL := path.Join(
+		glossaryBasePath,
+		url.PathEscape(string(accountUID)),
+		"glossaries", url.PathEscape(glossaryUID),
+		"import", url.PathEscape(importUID),
+	)
+
+	var response importStatusResponse
+	_, code, err := h.client.GetJSON(ctx, reqURL, nil, &response.Response.Data)
+	if err != nil && code == http.StatusNotFound {
+		return ImportStatusResponse{}, ErrImportNotFound
+	}
+	if err != nil {
+		return ImportStatusResponse{}, fmt.Errorf("failed to get import status: %w", err)
+	}
+
+	return toImportStatusResponse(response, code), nil
+}
+
+// ImportConfirm confirms a previously created glossary import.
+// Only imports in PENDING status may be confirmed.
+// Endpoint: POST /glossary-api/v3/accounts/{accountUid}/glossaries/{glossaryUid}/import/{importUid}/confirm.
+func (h httpGlossary) ImportConfirm(ctx context.Context, accountUID uid.AccountUID, glossaryUID, importUID string) (bool, error) {
+	reqURL := path.Join(glossaryBasePath, url.PathEscape(string(accountUID)), "glossaries", url.PathEscape(glossaryUID), "import", url.PathEscape(importUID), "confirm")
+
+	_, code, err := h.client.PostJSON(ctx, reqURL, nil, nil)
+	if err != nil && code == http.StatusNotFound {
+		return false, ErrImportNotFound
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to confirm glossary import: %w", err)
+	}
+
+	return true, nil
+}
+
+func buildImportForm(req ImportGlossaryRequest) ([]byte, string, error) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	// Per Smartling/api-docs GlossaryImportCommandPTO, the form fields are:
+	// importFile (binary), importFileName, importFileMediaType, archiveMode.
+	filePart, err := writer.CreateFormFile("importFile", req.FileName)
+	if err != nil {
+		return nil, "", fmt.Errorf("create importFile part: %w", err)
+	}
+	if _, err := filePart.Write(req.File); err != nil {
+		return nil, "", fmt.Errorf("write importFile part: %w", err)
+	}
+
+	if err := writer.WriteField("importFileName", req.FileName); err != nil {
+		return nil, "", fmt.Errorf("write importFileName field: %w", err)
+	}
+	if err := writer.WriteField("importFileMediaType", req.MediaType); err != nil {
+		return nil, "", fmt.Errorf("write importFileMediaType field: %w", err)
+	}
+	if err := writer.WriteField("archiveMode", strconv.FormatBool(req.ArchiveMode)); err != nil {
+		return nil, "", fmt.Errorf("write archiveMode field: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, "", fmt.Errorf("close multipart writer: %w", err)
+	}
+
+	return body.Bytes(), writer.FormDataContentType(), nil
+}

--- a/api/glossary/glossary_import.go
+++ b/api/glossary/glossary_import.go
@@ -51,7 +51,7 @@ func (h httpGlossary) Import(ctx context.Context,
 }
 
 // ImportStatus polls the status of a previously submitted glossary import.
-// Endpoint: GET /glossary-api/v3/accounts/{accountUid}/glossaries/{glossaryUid}/imports/{importUid}.
+// Endpoint: GET /glossary-api/v3/accounts/{accountUid}/glossaries/{glossaryUid}/import/{importUid}.
 func (h httpGlossary) ImportStatus(ctx context.Context, accountUID uid.AccountUID, glossaryUID, importUID string) (ImportStatusResponse, error) {
 	reqURL := path.Join(
 		glossaryBasePath,

--- a/api/mt/downloader.go
+++ b/api/mt/downloader.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/Smartling/api-sdk-go/helpers/sm_client"
 	"github.com/Smartling/api-sdk-go/helpers/sm_file"
+	"github.com/Smartling/api-sdk-go/helpers/uid"
 )
 
 // Downloader defines downloader behaviour
 type Downloader interface {
-	File(ctx context.Context, accountUID AccountUID, fileUID FileUID,
-		mtUID MtUID, localeID string) (io.ReadCloser, error)
+	File(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID,
+		mtUID uid.MtUID, localeID string) (io.ReadCloser, error)
 }
 
 // NewDownloader returns new Downloader implementation
@@ -30,8 +31,8 @@ func newHttpDownloader(base *base) *httpDownloader {
 }
 
 // File downloads file
-func (d httpDownloader) File(ctx context.Context, accountUID AccountUID, fileUID FileUID,
-	mtUID MtUID, localeID string) (io.ReadCloser, error) {
+func (d httpDownloader) File(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID,
+	mtUID uid.MtUID, localeID string) (io.ReadCloser, error) {
 	filePath := buildFilePath(accountUID, fileUID, mtUID, localeID)
 	path := joinPath(mtBasePath, filePath)
 	reader, code, err := d.base.client.Get(
@@ -52,6 +53,6 @@ func (d httpDownloader) File(ctx context.Context, accountUID AccountUID, fileUID
 	return reader, nil
 }
 
-func buildFilePath(accountUID AccountUID, fileUID FileUID, mtUID MtUID, localeID string) string {
+func buildFilePath(accountUID uid.AccountUID, fileUID uid.FileUID, mtUID uid.MtUID, localeID string) string {
 	return "/accounts/" + string(accountUID) + "/files/" + string(fileUID) + "/mt/" + string(mtUID) + "/locales/" + localeID + "/file"
 }

--- a/api/mt/file_translator.go
+++ b/api/mt/file_translator.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/Smartling/api-sdk-go/helpers/sm_client"
 	"github.com/Smartling/api-sdk-go/helpers/sm_file"
+	"github.com/Smartling/api-sdk-go/helpers/uid"
 )
 
 // FileTranslator defines file behaviour
 type FileTranslator interface {
-	Start(ctx context.Context, accountUID AccountUID, fileUID FileUID, p StartParams) (StartResponse, error)
-	Progress(ctx context.Context, accountUID AccountUID, fileUID FileUID, mtUID MtUID) (ProgressResponse, error)
+	Start(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID, p StartParams) (StartResponse, error)
+	Progress(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID, mtUID uid.MtUID) (ProgressResponse, error)
 }
 
 // NewFileTranslator returns new FileTranslator implementation
@@ -30,7 +31,7 @@ type StartParams struct {
 }
 
 // Start starts file translation
-func (h httpFileTranslator) Start(ctx context.Context, accountUID AccountUID, fileUID FileUID, p StartParams) (StartResponse, error) {
+func (h httpFileTranslator) Start(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID, p StartParams) (StartResponse, error) {
 	path := joinPath(mtBasePath, buildStartPath(accountUID, fileUID))
 
 	payload, err := json.Marshal(p)
@@ -48,7 +49,7 @@ func (h httpFileTranslator) Start(ctx context.Context, accountUID AccountUID, fi
 }
 
 // Progress return progress of file translation
-func (h httpFileTranslator) Progress(ctx context.Context, accountUID AccountUID, fileUID FileUID, mtUID MtUID) (ProgressResponse, error) {
+func (h httpFileTranslator) Progress(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID, mtUID uid.MtUID) (ProgressResponse, error) {
 	path := joinPath(mtBasePath, buildProgressPath(accountUID, fileUID, mtUID))
 
 	var response progressResponse
@@ -65,10 +66,10 @@ func (h httpFileTranslator) Progress(ctx context.Context, accountUID AccountUID,
 	return toProgressResponse(response), nil
 }
 
-func buildStartPath(accountUID AccountUID, fileUID FileUID) string {
+func buildStartPath(accountUID uid.AccountUID, fileUID uid.FileUID) string {
 	return "/accounts/" + string(accountUID) + "/files/" + string(fileUID) + "/mt"
 }
 
-func buildProgressPath(accountUID AccountUID, fileUID FileUID, mtUID MtUID) string {
+func buildProgressPath(accountUID uid.AccountUID, fileUID uid.FileUID, mtUID uid.MtUID) string {
 	return "/accounts/" + string(accountUID) + "/files/" + string(fileUID) + "/mt/" + string(mtUID) + "/status"
 }

--- a/api/mt/file_translator_ent.go
+++ b/api/mt/file_translator_ent.go
@@ -1,9 +1,11 @@
 package mt
 
+import "github.com/Smartling/api-sdk-go/helpers/uid"
+
 // StartResponse defines start translation response
 type StartResponse struct {
 	Code  int
-	MtUID MtUID
+	MtUID uid.MtUID
 }
 
 // startResponse defines start translation response as defined in API
@@ -19,7 +21,7 @@ type startResponse struct {
 func toStartResponse(r startResponse) StartResponse {
 	return StartResponse{
 		Code:  r.Response.Code,
-		MtUID: MtUID(r.Response.Data.MtUID),
+		MtUID: uid.MtUID(r.Response.Data.MtUID),
 	}
 }
 

--- a/api/mt/translation_control.go
+++ b/api/mt/translation_control.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 
 	"github.com/Smartling/api-sdk-go/helpers/sm_client"
+	"github.com/Smartling/api-sdk-go/helpers/uid"
 )
 
 // TranslationControl defines translation control behaviour
 type TranslationControl interface {
-	CancelTranslation(ctx context.Context, accountUID AccountUID, fileUID FileUID, mtUID MtUID) (CancelTranslationResponse, error)
-	DetectFileLanguage(ctx context.Context, accountUID AccountUID, fileUID FileUID) (DetectFileLanguageResponse, error)
-	DetectionProgress(ctx context.Context, accountUID AccountUID, fileUID FileUID, languageDetectionUID string) (DetectionProgressResponse, error)
+	CancelTranslation(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID, mtUID uid.MtUID) (CancelTranslationResponse, error)
+	DetectFileLanguage(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID) (DetectFileLanguageResponse, error)
+	DetectionProgress(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID, languageDetectionUID string) (DetectionProgressResponse, error)
 }
 
 // NewTranslationControl returns new TranslationControl implementation
@@ -24,7 +25,7 @@ type httpTranslationControl struct {
 }
 
 // CancelTranslation cancels translation
-func (h httpTranslationControl) CancelTranslation(ctx context.Context, accountUID AccountUID, fileUID FileUID, mtUID MtUID) (CancelTranslationResponse, error) {
+func (h httpTranslationControl) CancelTranslation(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID, mtUID uid.MtUID) (CancelTranslationResponse, error) {
 	path := joinPath(mtBasePath, buildCancelTranslationPath(accountUID, fileUID, mtUID))
 	var response cancelTranslationResponse
 	_, code, err := h.base.client.PostJSON(ctx, path, nil, &response.Response.Data)
@@ -36,7 +37,7 @@ func (h httpTranslationControl) CancelTranslation(ctx context.Context, accountUI
 }
 
 // DetectFileLanguage detects file language
-func (h httpTranslationControl) DetectFileLanguage(ctx context.Context, accountUID AccountUID, fileUID FileUID) (DetectFileLanguageResponse, error) {
+func (h httpTranslationControl) DetectFileLanguage(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID) (DetectFileLanguageResponse, error) {
 	path := joinPath(mtBasePath, buildDetectFileLanguagePath(accountUID, fileUID))
 	var response detectFileLanguageResponse
 	_, code, err := h.base.client.PostJSON(ctx, path, nil, &response.Response.Data)
@@ -48,7 +49,7 @@ func (h httpTranslationControl) DetectFileLanguage(ctx context.Context, accountU
 }
 
 // DetectionProgress returns info about detection
-func (h httpTranslationControl) DetectionProgress(ctx context.Context, accountUID AccountUID, fileUID FileUID, languageDetectionUID string) (DetectionProgressResponse, error) {
+func (h httpTranslationControl) DetectionProgress(ctx context.Context, accountUID uid.AccountUID, fileUID uid.FileUID, languageDetectionUID string) (DetectionProgressResponse, error) {
 	path := joinPath(mtBasePath, buildDetectionProgressPath(accountUID, fileUID, languageDetectionUID))
 	var response detectionProgressResponse
 	_, code, err := h.base.client.GetJSON(ctx, path, nil, &response.Response.Data)
@@ -59,14 +60,14 @@ func (h httpTranslationControl) DetectionProgress(ctx context.Context, accountUI
 	return toDetectionProgressResponse(response), nil
 }
 
-func buildCancelTranslationPath(accountUID AccountUID, fileUID FileUID, mtUID MtUID) string {
+func buildCancelTranslationPath(accountUID uid.AccountUID, fileUID uid.FileUID, mtUID uid.MtUID) string {
 	return "/accounts/" + string(accountUID) + "/files/" + string(fileUID) + "/mt/" + string(mtUID) + "/cancel"
 }
 
-func buildDetectFileLanguagePath(accountUID AccountUID, fileUID FileUID) string {
+func buildDetectFileLanguagePath(accountUID uid.AccountUID, fileUID uid.FileUID) string {
 	return "/accounts/" + string(accountUID) + "/files/" + string(fileUID) + "/language-detection"
 }
 
-func buildDetectionProgressPath(accountUID AccountUID, fileUID FileUID, languageDetectionUID string) string {
+func buildDetectionProgressPath(accountUID uid.AccountUID, fileUID uid.FileUID, languageDetectionUID string) string {
 	return "/accounts/" + string(accountUID) + "/files/" + string(fileUID) + "/language-detection/" + languageDetectionUID + "/status"
 }

--- a/api/mt/uploader.go
+++ b/api/mt/uploader.go
@@ -9,11 +9,12 @@ import (
 	"net/textproto"
 
 	"github.com/Smartling/api-sdk-go/helpers/sm_client"
+	"github.com/Smartling/api-sdk-go/helpers/uid"
 )
 
 // Uploader defines uploader behaviour
 type Uploader interface {
-	UploadFile(ctx context.Context, accountUID AccountUID, filename string, req UploadFileRequest) (UploadFileResponse, error)
+	UploadFile(ctx context.Context, accountUID uid.AccountUID, filename string, req UploadFileRequest) (UploadFileResponse, error)
 }
 
 // NewUploader returns new Uploader implementation
@@ -26,7 +27,7 @@ type httpUploader struct {
 }
 
 // UploadFile uploads file
-func (u httpUploader) UploadFile(ctx context.Context, accountUID AccountUID, filename string, req UploadFileRequest) (UploadFileResponse, error) {
+func (u httpUploader) UploadFile(ctx context.Context, accountUID uid.AccountUID, filename string, req UploadFileRequest) (UploadFileResponse, error) {
 	filePath := buildUploadFilePath(accountUID)
 	path := joinPath(mtBasePath, filePath)
 
@@ -90,6 +91,6 @@ func (u httpUploader) UploadFile(ctx context.Context, accountUID AccountUID, fil
 	return toUploadFileResponse(response), nil
 }
 
-func buildUploadFilePath(accountUID AccountUID) string {
+func buildUploadFilePath(accountUID uid.AccountUID) string {
 	return "/accounts/" + string(accountUID) + "/files"
 }

--- a/api/mt/uploader_ent.go
+++ b/api/mt/uploader_ent.go
@@ -1,9 +1,11 @@
 package mt
 
+import "github.com/Smartling/api-sdk-go/helpers/uid"
+
 // UploadFileResponse defines upload file response
 type UploadFileResponse struct {
 	Code    int
-	FileUID FileUID
+	FileUID uid.FileUID
 }
 
 // UploadFileRequest defines upload file request
@@ -26,6 +28,6 @@ type uploadFileResponse struct {
 func toUploadFileResponse(r uploadFileResponse) UploadFileResponse {
 	return UploadFileResponse{
 		Code:    r.Response.Code,
-		FileUID: FileUID(r.Response.Data.FileUID),
+		FileUID: uid.FileUID(r.Response.Data.FileUID),
 	}
 }

--- a/helpers/sm_error/empty_param_error.go
+++ b/helpers/sm_error/empty_param_error.go
@@ -1,4 +1,4 @@
-package mt
+package smerror
 
 import (
 	"errors"

--- a/helpers/sm_response/codes.go
+++ b/helpers/sm_response/codes.go
@@ -1,0 +1,16 @@
+package smresponse
+
+const (
+	StatusSuccess                    = "SUCCESS"
+	StatusAccepted                   = "ACCEPTED"
+	StatusValidationError            = "VALIDATION_ERROR"
+	StatusAuthenticationError        = "AUTHENTICATION_ERROR"
+	StatusAuthorizationError         = "AUTHORIZATION_ERROR"
+	StatusAccessDeniedError          = "ACCESS_DENIED_ERROR"
+	StatusNotFoundError              = "NOT_FOUND_ERROR"
+	StatusMaxOperationsLimitExceeded = "MAX_OPERATIONS_LIMIT_EXCEEDED"
+	StatusGeneralError               = "GENERAL_ERROR"
+	StatusMaintenanceModeError       = "MAINTENANCE_MODE_ERROR"
+	StatusResourceLocked             = "RESOURCE_LOCKED"
+	StatusUnauthorized               = "UNAUTHORIZED"
+)

--- a/helpers/uid/uid.go
+++ b/helpers/uid/uid.go
@@ -1,12 +1,16 @@
-package mt
+package uid
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/Smartling/api-sdk-go/helpers/sm_error"
+)
 
 type AccountUID string
 
 func (a AccountUID) Validate() error {
 	if strings.TrimSpace(string(a)) == "" {
-		return ErrEmptyParam("AccountUID")
+		return smerror.ErrEmptyParam("AccountUID")
 	}
 	return nil
 }
@@ -15,7 +19,7 @@ type FileUID string
 
 func (f FileUID) Validate() error {
 	if strings.TrimSpace(string(f)) == "" {
-		return ErrEmptyParam("FileUID")
+		return smerror.ErrEmptyParam("FileUID")
 	}
 	return nil
 }
@@ -24,7 +28,7 @@ type MtUID string
 
 func (m MtUID) Validate() error {
 	if strings.TrimSpace(string(m)) == "" {
-		return ErrEmptyParam("MtUID")
+		return smerror.ErrEmptyParam("MtUID")
 	}
 	return nil
 }


### PR DESCRIPTION
Added a new `api/glossary` package to the SDK, providing the API surface the CLI's glossaries commands build on.

New `Glossary` interface
- `Create` - create a glossary
- `Get`/`GetByName` - read a glossary by `UID` or `name`
- `Export` - export glossary entries (CSV / XLSX / TBX)
- `Import` / `ImportStatus` / `ImportConfirm` - upload a file and poll import progress

Supporting changes
- `helpers/` additions for `error/response/UID` handling used by the glossary endpoints
- Minor `api/mt` adjustments


https://github.com/Smartling/smartling-cli/pull/108