### PR TITLE
Rps 10164 Jobs read commands list view files

### DIFF
--- a/api/job/ent_job.go
+++ b/api/job/ent_job.go
@@ -1,62 +1,182 @@
 package job
 
-// GetJobResponse defines get job response
+import (
+	"fmt"
+	"time"
+
+	"github.com/Smartling/api-sdk-go/helpers"
+)
+
+// JobSourceFile is a source file attached to a job.
+type JobSourceFile struct {
+	Name    string
+	URI     string
+	FileUID string
+}
+
+// JobCustomField is a custom field value on a job.
+type JobCustomField struct {
+	FieldUID   string
+	FieldName  string
+	FieldValue string
+}
+
+// JobIssues holds the issue counts on a job.
+type JobIssues struct {
+	SourceIssuesCount      int
+	TranslationIssuesCount int
+}
+
+// JobDates groups the timestamps on a job. Fields the API omits (e.g.
+// completion dates on an in-progress job) are the zero time.Time.
+type JobDates struct {
+	Due             time.Time
+	Modified        time.Time
+	Created         time.Time
+	FirstAuthorized time.Time
+	LastAuthorized  time.Time
+	FirstCompleted  time.Time
+	LastCompleted   time.Time
+}
+
+// GetJobResponse defines the full job detail response.
 type GetJobResponse struct {
 	Code              int
 	TranslationJobUID string
 	JobName           string
+	JobNumber         string
+	Description       string
+	ReferenceNumber   string
+	JobStatus         string
+	Priority          int
 	TargetLocaleIDs   []string
+	SourceFiles       []JobSourceFile
+	CustomFields      []JobCustomField
+	Issues            JobIssues
+	CreatedByUserUID  string
+	ModifiedByUserUID string
+	Dates             JobDates
 }
 
-// FindFirstJobByName finds the first job by name from the list of jobs
-func FindFirstJobByName(jobs []GetJobResponse, name string) (GetJobResponse, bool) {
+// FindFirstJobByName finds the first job by name from the list of jobs.
+func FindFirstJobByName(jobs []JobSummary, name string) (JobSummary, bool) {
 	for _, job := range jobs {
 		if job.JobName == name {
 			return job, true
 		}
 	}
-	return GetJobResponse{}, false
+	return JobSummary{}, false
 }
 
 type getJobResponse struct {
 	Response struct {
 		Code int
 		Data struct {
-			JobName           string   `json:"jobName"`
-			TranslationJobUID string   `json:"translationJobUid"`
-			TargetLocaleIDs   []string `json:"targetLocaleIds"`
+			TranslationJobUID   string   `json:"translationJobUid"`
+			JobName             string   `json:"jobName"`
+			JobNumber           string   `json:"jobNumber"`
+			Description         string   `json:"description"`
+			ReferenceNumber     string   `json:"referenceNumber"`
+			JobStatus           string   `json:"jobStatus"`
+			DueDate             string   `json:"dueDate"`
+			ModifiedDate        string   `json:"modifiedDate"`
+			CreatedDate         string   `json:"createdDate"`
+			ModifiedByUserUID   string   `json:"modifiedByUserUid"`
+			CreatedByUserUID    string   `json:"createdByUserUid"`
+			FirstAuthorizedDate string   `json:"firstAuthorizedDate"`
+			LastAuthorizedDate  string   `json:"lastAuthorizedDate"`
+			FirstCompletedDate  string   `json:"firstCompletedDate"`
+			LastCompletedDate   string   `json:"lastCompletedDate"`
+			Priority            int      `json:"priority"`
+			TargetLocaleIDs     []string `json:"targetLocaleIds"`
+			SourceFiles         []struct {
+				Name    string `json:"name"`
+				URI     string `json:"uri"`
+				FileUID string `json:"fileUid"`
+			} `json:"sourceFiles"`
+			CustomFields []struct {
+				FieldUID   string `json:"fieldUid"`
+				FieldName  string `json:"fieldName"`
+				FieldValue string `json:"fieldValue"`
+			} `json:"customFields"`
+			Issues struct {
+				SourceIssuesCount      int `json:"sourceIssuesCount"`
+				TranslationIssuesCount int `json:"translationIssuesCount"`
+			} `json:"issues"`
 		} `json:"data"`
 	} `json:"response"`
 }
 
-func toGetJobResponse(r getJobResponse) GetJobResponse {
+func toGetJobResponse(r getJobResponse) (GetJobResponse, error) {
+	data := r.Response.Data
+	sourceFiles := make([]JobSourceFile, 0, len(data.SourceFiles))
+	for _, f := range data.SourceFiles {
+		sourceFiles = append(sourceFiles, JobSourceFile{Name: f.Name, URI: f.URI, FileUID: f.FileUID})
+	}
+	customFields := make([]JobCustomField, 0, len(data.CustomFields))
+	for _, c := range data.CustomFields {
+		customFields = append(customFields, JobCustomField{FieldUID: c.FieldUID, FieldName: c.FieldName, FieldValue: c.FieldValue})
+	}
+
+	dates, err := toJobDates(r)
+	if err != nil {
+		return GetJobResponse{}, err
+	}
+
 	return GetJobResponse{
 		Code:              r.Response.Code,
-		TranslationJobUID: r.Response.Data.TranslationJobUID,
-		JobName:           r.Response.Data.JobName,
-		TargetLocaleIDs:   r.Response.Data.TargetLocaleIDs,
-	}
+		TranslationJobUID: data.TranslationJobUID,
+		JobName:           data.JobName,
+		JobNumber:         data.JobNumber,
+		Description:       data.Description,
+		ReferenceNumber:   data.ReferenceNumber,
+		JobStatus:         data.JobStatus,
+		Priority:          data.Priority,
+		TargetLocaleIDs:   data.TargetLocaleIDs,
+		SourceFiles:       sourceFiles,
+		CustomFields:      customFields,
+		Issues: JobIssues{
+			SourceIssuesCount:      data.Issues.SourceIssuesCount,
+			TranslationIssuesCount: data.Issues.TranslationIssuesCount,
+		},
+		CreatedByUserUID:  data.CreatedByUserUID,
+		ModifiedByUserUID: data.ModifiedByUserUID,
+		Dates:             dates,
+	}, nil
 }
 
-type getJobsResponse struct {
-	Response struct {
-		Code string `json:"code"`
-		Data struct {
-			Items []struct {
-				JobName           string `json:"jobName"`
-				TranslationJobUID string `json:"translationJobUid"`
-			} `json:"items"`
-		} `json:"data"`
-	} `json:"response"`
-}
-
-func toGetJobsResponse(r getJobsResponse) []GetJobResponse {
-	res := make([]GetJobResponse, len(r.Response.Data.Items))
-	for i, job := range r.Response.Data.Items {
-		res[i] = GetJobResponse{
-			TranslationJobUID: job.TranslationJobUID,
-			JobName:           job.JobName,
-		}
+// toJobDates converts the raw timestamps to JobDates, failing fast on the
+// first unparseable value so the caller can decide how to handle it.
+func toJobDates(r getJobResponse) (JobDates, error) {
+	var res JobDates
+	var err error
+	res.Due, err = helpers.StringToTime(r.Response.Data.DueDate, time.RFC3339)
+	if err != nil {
+		return JobDates{}, fmt.Errorf("parse DueDate: %w", err)
 	}
-	return res
+	res.Modified, err = helpers.StringToTime(r.Response.Data.ModifiedDate, time.RFC3339)
+	if err != nil {
+		return JobDates{}, fmt.Errorf("parse ModifiedDate: %w", err)
+	}
+	res.Created, err = helpers.StringToTime(r.Response.Data.CreatedDate, time.RFC3339)
+	if err != nil {
+		return JobDates{}, fmt.Errorf("parse CreatedDate: %w", err)
+	}
+	res.FirstAuthorized, err = helpers.StringToTime(r.Response.Data.FirstAuthorizedDate, time.RFC3339)
+	if err != nil {
+		return JobDates{}, fmt.Errorf("parse FirstAuthorizedDate: %w", err)
+	}
+	res.LastAuthorized, err = helpers.StringToTime(r.Response.Data.LastAuthorizedDate, time.RFC3339)
+	if err != nil {
+		return JobDates{}, fmt.Errorf("parse LastAuthorizedDate: %w", err)
+	}
+	res.FirstCompleted, err = helpers.StringToTime(r.Response.Data.FirstCompletedDate, time.RFC3339)
+	if err != nil {
+		return JobDates{}, fmt.Errorf("parse FirstCompletedDate: %w", err)
+	}
+	res.LastCompleted, err = helpers.StringToTime(r.Response.Data.LastCompletedDate, time.RFC3339)
+	if err != nil {
+		return JobDates{}, fmt.Errorf("parse LastCompletedDate: %w", err)
+	}
+	return res, nil
 }

--- a/api/job/ent_job_list.go
+++ b/api/job/ent_job_list.go
@@ -1,0 +1,108 @@
+package job
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Smartling/api-sdk-go/helpers"
+)
+
+// JobSummary is a single row in a jobs listing. ProjectID and Priority are
+// only populated by the account-level listing.
+type JobSummary struct {
+	TranslationJobUID string
+	JobName           string
+	JobNumber         string
+	Description       string
+	JobStatus         string
+	ReferenceNumber   string
+	TargetLocaleIDs   []string
+	ProjectID         string
+	Priority          int
+	Dates             JobDates
+}
+
+// ListJobsResponse is a single page of a jobs listing.
+type ListJobsResponse struct {
+	Items      []JobSummary
+	TotalCount int
+}
+
+// ListProjectJobsParams carries filters for listing jobs within a project.
+type ListProjectJobsParams struct {
+	JobName            string
+	JobNumber          string
+	TranslationJobUIDs []string
+	JobStatus          []string
+	Limit              uint32
+	Offset             uint32
+	SortBy             string
+	SortDirection      string
+}
+
+// ListAccountJobsParams carries filters for listing jobs within an account.
+type ListAccountJobsParams struct {
+	JobName       string
+	ProjectIDs    []string
+	JobStatus     []string
+	WithPriority  bool
+	Limit         uint32
+	Offset        uint32
+	SortBy        string
+	SortDirection string
+}
+
+// SearchJobsRequest is the body of the jobs search endpoint.
+type SearchJobsRequest struct {
+	FileURIs           []string
+	Hashcodes          []string
+	TranslationJobUIDs []string
+}
+
+// listJobsData is the shared wire shape of project, account, and search
+// list responses.
+type listJobsData struct {
+	TotalCount int `json:"totalCount"`
+	Items      []struct {
+		TranslationJobUID string   `json:"translationJobUid"`
+		JobName           string   `json:"jobName"`
+		JobNumber         string   `json:"jobNumber"`
+		Description       string   `json:"description"`
+		JobStatus         string   `json:"jobStatus"`
+		DueDate           string   `json:"dueDate"`
+		CreatedDate       string   `json:"createdDate"`
+		ReferenceNumber   string   `json:"referenceNumber"`
+		TargetLocaleIDs   []string `json:"targetLocaleIds"`
+		ProjectID         string   `json:"projectId"`
+		Priority          int      `json:"priority"`
+	} `json:"items"`
+}
+
+func toListJobsResponse(d listJobsData) (ListJobsResponse, error) {
+	items := make([]JobSummary, 0, len(d.Items))
+	for _, item := range d.Items {
+		var dates JobDates
+		var err error
+		dates.Due, err = helpers.StringToTime(item.DueDate, time.RFC3339)
+		if err != nil {
+			return ListJobsResponse{}, fmt.Errorf("parse DueDate: %w", err)
+		}
+		dates.Created, err = helpers.StringToTime(item.CreatedDate, time.RFC3339)
+		if err != nil {
+			return ListJobsResponse{}, fmt.Errorf("parse CreatedDate: %w", err)
+		}
+		items = append(items, JobSummary{
+			TranslationJobUID: item.TranslationJobUID,
+			JobName:           item.JobName,
+			JobNumber:         item.JobNumber,
+			Description:       item.Description,
+			JobStatus:         item.JobStatus,
+			ReferenceNumber:   item.ReferenceNumber,
+			TargetLocaleIDs:   item.TargetLocaleIDs,
+			ProjectID:         item.ProjectID,
+			Priority:          item.Priority,
+			Dates:             dates,
+		})
+	}
+	return ListJobsResponse{Items: items, TotalCount: d.TotalCount}, nil
+}

--- a/api/job/ent_job_list.go
+++ b/api/job/ent_job_list.go
@@ -8,7 +8,7 @@ import (
 )
 
 // JobSummary is a single row in a jobs listing. ProjectID and Priority are
-// only populated by the account-level listing.
+// only returned by the account-level endpoint and are the zero value otherwise.
 type JobSummary struct {
 	TranslationJobUID string
 	JobName           string
@@ -34,22 +34,18 @@ type ListProjectJobsParams struct {
 	JobNumber          string
 	TranslationJobUIDs []string
 	JobStatus          []string
-	Limit              uint32
-	Offset             uint32
-	SortBy             string
-	SortDirection      string
+	Page               Page
+	Sort               Sort
 }
 
 // ListAccountJobsParams carries filters for listing jobs within an account.
 type ListAccountJobsParams struct {
-	JobName       string
-	ProjectIDs    []string
-	JobStatus     []string
-	WithPriority  bool
-	Limit         uint32
-	Offset        uint32
-	SortBy        string
-	SortDirection string
+	JobName      string
+	ProjectIDs   []string
+	JobStatus    []string
+	WithPriority bool
+	Page         Page
+	Sort         Sort
 }
 
 // SearchJobsRequest is the body of the jobs search endpoint.
@@ -105,4 +101,14 @@ func toListJobsResponse(d listJobsData) (ListJobsResponse, error) {
 		})
 	}
 	return ListJobsResponse{Items: items, TotalCount: d.TotalCount}, nil
+}
+
+type Page struct {
+	Limit  uint32
+	Offset uint32
+}
+
+type Sort struct {
+	SortBy        string
+	SortDirection string
 }

--- a/api/job/job.go
+++ b/api/job/job.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,14 +13,19 @@ import (
 	smclient "github.com/Smartling/api-sdk-go/helpers/sm_client"
 )
 
-const jobBasePath = "/jobs-api/v3/projects/"
+const (
+	jobBasePath     = "/jobs-api/v3/projects/"
+	accountBasePath = "/jobs-api/v3/accounts/"
+)
 
 var ErrNotFound = errors.New("job not found")
 
 // Job defines the job behaviour
 type Job interface {
 	GetJob(ctx context.Context, projectID, jobUID string) (GetJobResponse, error)
-	SearchByName(ctx context.Context, projectID, name string) (jobs []GetJobResponse, err error)
+	ListProjectJobs(ctx context.Context, projectID string, params ListProjectJobsParams) (ListJobsResponse, error)
+	ListAccountJobs(ctx context.Context, accountUID string, params ListAccountJobsParams) (ListJobsResponse, error)
+	SearchJobs(ctx context.Context, projectID string, req SearchJobsRequest) (ListJobsResponse, error)
 	Progress(ctx context.Context, projectID string, jobUID string) (GetJobProgressResponse, error)
 	ListFiles(ctx context.Context, projectID, jobUID string, limit, offset uint32) (ListJobFilesResponse, error)
 }
@@ -51,23 +57,113 @@ func (h httpJob) GetJob(ctx context.Context, projectID, jobUID string) (GetJobRe
 		return GetJobResponse{}, fmt.Errorf("failed to get job: %w", err)
 	}
 	response.Response.Code = code
-	return toGetJobResponse(response), nil
+	return toGetJobResponse(response)
 }
 
-// SearchByName searches all jobs of a project by name
-func (h httpJob) SearchByName(ctx context.Context, projectID, name string) ([]GetJobResponse, error) {
+// ListProjectJobs lists jobs within a project, applying the given filters.
+func (h httpJob) ListProjectJobs(ctx context.Context, projectID string, params ListProjectJobsParams) (ListJobsResponse, error) {
 	reqURL := path.Join(jobBasePath, url.PathEscape(projectID), "jobs")
 
-	params := url.Values{}
-	params.Set("jobName", name)
-
-	var res getJobsResponse
-	_, _, err := h.client.GetJSON(ctx, reqURL, params, &res.Response.Data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get jobs: %w", err)
+	q := url.Values{}
+	if params.JobName != "" {
+		q.Set("jobName", params.JobName)
 	}
-	jobs := toGetJobsResponse(res)
-	return jobs, nil
+	if params.JobNumber != "" {
+		q.Set("jobNumber", params.JobNumber)
+	}
+	for _, uid := range params.TranslationJobUIDs {
+		q.Add("translationJobUids", uid)
+	}
+	for _, st := range params.JobStatus {
+		q.Add("translationJobStatus", st)
+	}
+	if params.Limit > 0 {
+		q.Set("limit", strconv.FormatUint(uint64(params.Limit), 10))
+	}
+	if params.Offset > 0 {
+		q.Set("offset", strconv.FormatUint(uint64(params.Offset), 10))
+	}
+	if params.SortBy != "" {
+		q.Set("sortBy", params.SortBy)
+	}
+	if params.SortDirection != "" {
+		q.Set("sortDirection", params.SortDirection)
+	}
+
+	var data listJobsData
+	_, code, err := h.client.GetJSON(ctx, reqURL, q, &data)
+	if err != nil && code == http.StatusNotFound {
+		return ListJobsResponse{}, ErrNotFound
+	}
+	if err != nil {
+		return ListJobsResponse{}, fmt.Errorf("failed to list jobs: %w", err)
+	}
+	return toListJobsResponse(data)
+}
+
+// ListAccountJobs lists jobs within an account, applying the given filters.
+func (h httpJob) ListAccountJobs(ctx context.Context, accountUID string, params ListAccountJobsParams) (ListJobsResponse, error) {
+	reqURL := path.Join(accountBasePath, url.PathEscape(accountUID), "jobs")
+
+	q := url.Values{}
+	if params.JobName != "" {
+		q.Set("jobName", params.JobName)
+	}
+	for _, pid := range params.ProjectIDs {
+		q.Add("projectIds", pid)
+	}
+	for _, st := range params.JobStatus {
+		q.Add("translationJobStatus", st)
+	}
+	if params.WithPriority {
+		q.Set("withPriority", "true")
+	}
+	if params.Limit > 0 {
+		q.Set("limit", strconv.FormatUint(uint64(params.Limit), 10))
+	}
+	if params.Offset > 0 {
+		q.Set("offset", strconv.FormatUint(uint64(params.Offset), 10))
+	}
+	if params.SortBy != "" {
+		q.Set("sortBy", params.SortBy)
+	}
+	if params.SortDirection != "" {
+		q.Set("sortDirection", params.SortDirection)
+	}
+
+	var data listJobsData
+	_, code, err := h.client.GetJSON(ctx, reqURL, q, &data)
+	if err != nil && code == http.StatusNotFound {
+		return ListJobsResponse{}, ErrNotFound
+	}
+	if err != nil {
+		return ListJobsResponse{}, fmt.Errorf("failed to list account jobs: %w", err)
+	}
+	return toListJobsResponse(data)
+}
+
+// SearchJobs finds jobs by file URIs, hashcodes, or job UIDs.
+func (h httpJob) SearchJobs(ctx context.Context, projectID string, req SearchJobsRequest) (ListJobsResponse, error) {
+	reqURL := path.Join(jobBasePath, url.PathEscape(projectID), "jobs", "search")
+
+	body, err := json.Marshal(map[string][]string{
+		"fileUris":           req.FileURIs,
+		"hashcodes":          req.Hashcodes,
+		"translationJobUids": req.TranslationJobUIDs,
+	})
+	if err != nil {
+		return ListJobsResponse{}, fmt.Errorf("failed to encode search request: %w", err)
+	}
+
+	var data listJobsData
+	_, code, err := h.client.PostJSON(ctx, reqURL, body, &data)
+	if err != nil && code == http.StatusNotFound {
+		return ListJobsResponse{}, ErrNotFound
+	}
+	if err != nil {
+		return ListJobsResponse{}, fmt.Errorf("failed to search jobs: %w", err)
+	}
+	return toListJobsResponse(data)
 }
 
 // ListFiles returns a single page of source files attached to a translation job.

--- a/api/job/job.go
+++ b/api/job/job.go
@@ -77,17 +77,17 @@ func (h httpJob) ListProjectJobs(ctx context.Context, projectID string, params L
 	for _, st := range params.JobStatus {
 		q.Add("translationJobStatus", st)
 	}
-	if params.Limit > 0 {
-		q.Set("limit", strconv.FormatUint(uint64(params.Limit), 10))
+	if params.Page.Limit > 0 {
+		q.Set("limit", strconv.FormatUint(uint64(params.Page.Limit), 10))
 	}
-	if params.Offset > 0 {
-		q.Set("offset", strconv.FormatUint(uint64(params.Offset), 10))
+	if params.Page.Offset > 0 {
+		q.Set("offset", strconv.FormatUint(uint64(params.Page.Offset), 10))
 	}
-	if params.SortBy != "" {
-		q.Set("sortBy", params.SortBy)
+	if params.Sort.SortBy != "" {
+		q.Set("sortBy", params.Sort.SortBy)
 	}
-	if params.SortDirection != "" {
-		q.Set("sortDirection", params.SortDirection)
+	if params.Sort.SortDirection != "" {
+		q.Set("sortDirection", params.Sort.SortDirection)
 	}
 
 	var data listJobsData
@@ -118,17 +118,17 @@ func (h httpJob) ListAccountJobs(ctx context.Context, accountUID string, params 
 	if params.WithPriority {
 		q.Set("withPriority", "true")
 	}
-	if params.Limit > 0 {
-		q.Set("limit", strconv.FormatUint(uint64(params.Limit), 10))
+	if params.Page.Limit > 0 {
+		q.Set("limit", strconv.FormatUint(uint64(params.Page.Limit), 10))
 	}
-	if params.Offset > 0 {
-		q.Set("offset", strconv.FormatUint(uint64(params.Offset), 10))
+	if params.Page.Offset > 0 {
+		q.Set("offset", strconv.FormatUint(uint64(params.Page.Offset), 10))
 	}
-	if params.SortBy != "" {
-		q.Set("sortBy", params.SortBy)
+	if params.Sort.SortBy != "" {
+		q.Set("sortBy", params.Sort.SortBy)
 	}
-	if params.SortDirection != "" {
-		q.Set("sortDirection", params.SortDirection)
+	if params.Sort.SortDirection != "" {
+		q.Set("sortDirection", params.Sort.SortDirection)
 	}
 
 	var data listJobsData
@@ -146,11 +146,18 @@ func (h httpJob) ListAccountJobs(ctx context.Context, accountUID string, params 
 func (h httpJob) SearchJobs(ctx context.Context, projectID string, req SearchJobsRequest) (ListJobsResponse, error) {
 	reqURL := path.Join(jobBasePath, url.PathEscape(projectID), "jobs", "search")
 
-	body, err := json.Marshal(map[string][]string{
-		"fileUris":           req.FileURIs,
-		"hashcodes":          req.Hashcodes,
-		"translationJobUids": req.TranslationJobUIDs,
-	})
+	payload := map[string][]string{}
+	if len(req.FileURIs) > 0 {
+		payload["fileUris"] = req.FileURIs
+	}
+	if len(req.Hashcodes) > 0 {
+		payload["hashcodes"] = req.Hashcodes
+	}
+	if len(req.TranslationJobUIDs) > 0 {
+		payload["translationJobUids"] = req.TranslationJobUIDs
+	}
+
+	body, err := json.Marshal(payload)
 	if err != nil {
 		return ListJobsResponse{}, fmt.Errorf("failed to encode search request: %w", err)
 	}

--- a/api/job/job_test.go
+++ b/api/job/job_test.go
@@ -152,7 +152,7 @@ func TestListProjectJobs_ForwardsFiltersAndMapsItems(t *testing.T) {
 	resp, err := j.ListProjectJobs(context.Background(), "projectId-xyz", ListProjectJobsParams{
 		JobName:   "Release",
 		JobStatus: []string{"IN_PROGRESS"},
-		Limit:     10,
+		Page:      Page{Limit: 10},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/api/job/job_test.go
+++ b/api/job/job_test.go
@@ -121,6 +121,24 @@ func TestGetJob_PopulatesDetailFields(t *testing.T) {
 	if resp.Issues.TranslationIssuesCount != 2 {
 		t.Errorf("Issues.TranslationIssuesCount = %d, want 2", resp.Issues.TranslationIssuesCount)
 	}
+	wantDue := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	if !resp.Dates.Due.Equal(wantDue) {
+		t.Errorf("Dates.Due = %v, want %v", resp.Dates.Due, wantDue)
+	}
+	wantCreated := time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC)
+	if !resp.Dates.Created.Equal(wantCreated) {
+		t.Errorf("Dates.Created = %v, want %v", resp.Dates.Created, wantCreated)
+	}
+	wantModified := time.Date(2025, 12, 2, 0, 0, 0, 0, time.UTC)
+	if !resp.Dates.Modified.Equal(wantModified) {
+		t.Errorf("Dates.Modified = %v, want %v", resp.Dates.Modified, wantModified)
+	}
+	if !resp.Dates.FirstCompleted.IsZero() {
+		t.Errorf("Dates.FirstCompleted = %v, want zero (job in progress)", resp.Dates.FirstCompleted)
+	}
+	if !resp.Dates.LastCompleted.IsZero() {
+		t.Errorf("Dates.LastCompleted = %v, want zero (job in progress)", resp.Dates.LastCompleted)
+	}
 }
 
 func TestListProjectJobs_ForwardsFiltersAndMapsItems(t *testing.T) {

--- a/api/job/job_test.go
+++ b/api/job/job_test.go
@@ -2,7 +2,9 @@ package job
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -64,6 +66,173 @@ func TestGetJob_PopulatesTargetLocaleIDs(t *testing.T) {
 	}
 	if resp.TranslationJobUID != "jobUid-123" {
 		t.Errorf("TranslationJobUID: got %q, want %q", resp.TranslationJobUID, "jobUid-123")
+	}
+}
+
+func TestGetJob_PopulatesDetailFields(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"response": {
+				"code": "SUCCESS",
+				"data": {
+					"translationJobUid": "jobUid-123",
+					"jobName": "My Job",
+					"jobNumber": "SMTL-7",
+					"description": "desc",
+					"referenceNumber": "ref-1",
+					"jobStatus": "IN_PROGRESS",
+					"dueDate": "2026-01-02T00:00:00Z",
+					"createdDate": "2025-12-01T00:00:00Z",
+					"modifiedDate": "2025-12-02T00:00:00Z",
+					"createdByUserUid": "u-created",
+					"modifiedByUserUid": "u-modified",
+					"priority": 4,
+					"targetLocaleIds": ["fr-FR"],
+					"sourceFiles": [{"name": "a.json", "uri": "a.json", "fileUid": "f1"}],
+					"customFields": [{"fieldUid": "cf1", "fieldName": "Dept", "fieldValue": "Eng"}],
+					"issues": {"sourceIssuesCount": 1, "translationIssuesCount": 2}
+				}
+			}
+		}`))
+	}
+
+	j, _ := newTestJob(t, handler)
+
+	resp, err := j.GetJob(context.Background(), "projectId-xyz", "jobUid-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.JobNumber != "SMTL-7" {
+		t.Errorf("JobNumber = %q, want %q", resp.JobNumber, "SMTL-7")
+	}
+	if resp.JobStatus != "IN_PROGRESS" {
+		t.Errorf("JobStatus = %q, want %q", resp.JobStatus, "IN_PROGRESS")
+	}
+	if resp.Priority != 4 {
+		t.Errorf("Priority = %d, want 4", resp.Priority)
+	}
+	if len(resp.SourceFiles) != 1 || resp.SourceFiles[0].URI != "a.json" {
+		t.Errorf("SourceFiles = %v, want one file a.json", resp.SourceFiles)
+	}
+	if len(resp.CustomFields) != 1 || resp.CustomFields[0].FieldName != "Dept" {
+		t.Errorf("CustomFields = %v, want one Dept", resp.CustomFields)
+	}
+	if resp.Issues.TranslationIssuesCount != 2 {
+		t.Errorf("Issues.TranslationIssuesCount = %d, want 2", resp.Issues.TranslationIssuesCount)
+	}
+}
+
+func TestListProjectJobs_ForwardsFiltersAndMapsItems(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/projects/projectId-xyz/jobs") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("jobName") != "Release" {
+			t.Errorf("jobName = %q, want Release", q.Get("jobName"))
+		}
+		if q.Get("translationJobStatus") != "IN_PROGRESS" {
+			t.Errorf("translationJobStatus = %q, want IN_PROGRESS", q.Get("translationJobStatus"))
+		}
+		if q.Get("limit") != "10" {
+			t.Errorf("limit = %q, want 10", q.Get("limit"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"response": {"code": "SUCCESS", "data": {
+				"totalCount": 1,
+				"items": [{"translationJobUid": "u1", "jobName": "Release", "jobStatus": "IN_PROGRESS", "targetLocaleIds": ["fr-FR"]}]
+			}}
+		}`))
+	}
+
+	j, _ := newTestJob(t, handler)
+
+	resp, err := j.ListProjectJobs(context.Background(), "projectId-xyz", ListProjectJobsParams{
+		JobName:   "Release",
+		JobStatus: []string{"IN_PROGRESS"},
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.TotalCount != 1 {
+		t.Errorf("TotalCount = %d, want 1", resp.TotalCount)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].TranslationJobUID != "u1" {
+		t.Fatalf("Items = %v, want one u1", resp.Items)
+	}
+	if resp.Items[0].JobStatus != "IN_PROGRESS" {
+		t.Errorf("Items[0].JobStatus = %q, want IN_PROGRESS", resp.Items[0].JobStatus)
+	}
+}
+
+func TestListAccountJobs_UsesAccountPathAndMapsProjectAndPriority(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/accounts/acct-1/jobs") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("withPriority") != "true" {
+			t.Errorf("withPriority = %q, want true", r.URL.Query().Get("withPriority"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"response": {"code": "SUCCESS", "data": {
+				"totalCount": 1,
+				"items": [{"translationJobUid": "u1", "jobName": "A", "projectId": "p9", "priority": 3}]
+			}}
+		}`))
+	}
+
+	j, _ := newTestJob(t, handler)
+
+	resp, err := j.ListAccountJobs(context.Background(), "acct-1", ListAccountJobsParams{WithPriority: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("Items = %v, want one", resp.Items)
+	}
+	if resp.Items[0].ProjectID != "p9" {
+		t.Errorf("ProjectID = %q, want p9", resp.Items[0].ProjectID)
+	}
+	if resp.Items[0].Priority != 3 {
+		t.Errorf("Priority = %d, want 3", resp.Items[0].Priority)
+	}
+}
+
+func TestSearchJobs_PostsBodyAndMapsItems(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/projects/p1/jobs/search") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var got map[string][]string
+		_ = json.Unmarshal(body, &got)
+		if len(got["fileUris"]) != 1 || got["fileUris"][0] != "a.json" {
+			t.Errorf("fileUris = %v, want [a.json]", got["fileUris"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"response": {"code": "SUCCESS", "data": {
+				"totalCount": 1,
+				"items": [{"translationJobUid": "u1", "jobName": "Found"}]
+			}}
+		}`))
+	}
+
+	j, _ := newTestJob(t, handler)
+
+	resp, err := j.SearchJobs(context.Background(), "p1", SearchJobsRequest{FileURIs: []string{"a.json"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].JobName != "Found" {
+		t.Fatalf("Items = %v, want one Found", resp.Items)
 	}
 }
 

--- a/helpers/conversion.go
+++ b/helpers/conversion.go
@@ -1,0 +1,13 @@
+package helpers
+
+import "time"
+
+// StringToTime converts a timestamp string in the given layout to time.Time.
+// An empty string yields the zero time and a nil error; a non-empty string
+// that fails to parse returns the parse error.
+func StringToTime(s, layout string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse(layout, s)
+}


### PR DESCRIPTION
New Job interface methods

- `ListProjectJobs(ctx, projectID, ListProjectJobsParams)` - list jobs in a project with name/number/status/UID filters, sorting, and pagination.
- `ListAccountJobs(ctx, accountUID, ListAccountJobsParams)` - list jobs across an account (project-id/status filters, withPriority, sorting, pagination).
- `SearchJobs(ctx, projectID, SearchJobsRequest)` - find jobs by file URIs, hashcodes, or job UIDs.

https://github.com/Smartling/smartling-cli/pull/109