### PR TITLE
Rps 10166 job locales

### DIFF
--- a/api/job/locale/locale.go
+++ b/api/job/locale/locale.go
@@ -1,0 +1,74 @@
+package locale
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+
+	smclient "github.com/Smartling/api-sdk-go/helpers/sm_client"
+	smerror "github.com/Smartling/api-sdk-go/helpers/sm_error"
+)
+
+const jobBasePath = "/jobs-api/v3/projects/"
+
+// JobLocale manages target locales on a translation job.
+type JobLocale interface {
+	Add(ctx context.Context, projectID, jobUID, targetLocaleID string) error
+	Remove(ctx context.Context, projectID, jobUID, targetLocaleID string) error
+}
+
+// NewJobLocale returns new JobLocale implementation
+func NewJobLocale(client *smclient.Client) JobLocale {
+	return newHttpJobLocale(client)
+}
+
+// httpJobLocale implements JobLocale interface using HTTP client
+type httpJobLocale struct {
+	client *smclient.Client
+}
+
+func newHttpJobLocale(client *smclient.Client) httpJobLocale {
+	return httpJobLocale{client: client}
+}
+
+// Add assigns a target locale to a translation job.
+func (h httpJobLocale) Add(ctx context.Context, projectID, jobUID, targetLocaleID string) error {
+	if err := requireParams(projectID, jobUID, targetLocaleID); err != nil {
+		return err
+	}
+	reqURL := localeURL(projectID, jobUID, targetLocaleID)
+	if _, _, err := h.client.PostJSON(ctx, reqURL, nil, nil); err != nil {
+		return fmt.Errorf("failed to add locale to job: %w", err)
+	}
+	return nil
+}
+
+// Remove unassigns a target locale from a translation job.
+func (h httpJobLocale) Remove(ctx context.Context, projectID, jobUID, targetLocaleID string) error {
+	if err := requireParams(projectID, jobUID, targetLocaleID); err != nil {
+		return err
+	}
+	reqURL := localeURL(projectID, jobUID, targetLocaleID)
+	if _, _, err := h.client.DeleteJSON(ctx, reqURL, nil); err != nil {
+		return fmt.Errorf("failed to remove locale from job: %w", err)
+	}
+	return nil
+}
+
+func localeURL(projectID, translationJobUID, targetLocaleID string) string {
+	return path.Join(jobBasePath, url.PathEscape(projectID), "jobs",
+		url.PathEscape(translationJobUID), "locales", url.PathEscape(targetLocaleID))
+}
+
+func requireParams(projectID, translationJobUID, targetLocaleID string) error {
+	switch {
+	case projectID == "":
+		return smerror.ErrEmptyParam("projectID")
+	case translationJobUID == "":
+		return smerror.ErrEmptyParam("translationJobUID")
+	case targetLocaleID == "":
+		return smerror.ErrEmptyParam("targetLocaleID")
+	}
+	return nil
+}

--- a/api/job/locale/locale.go
+++ b/api/job/locale/locale.go
@@ -56,17 +56,17 @@ func (h httpJobLocale) Remove(ctx context.Context, projectID, jobUID, targetLoca
 	return nil
 }
 
-func localeURL(projectID, translationJobUID, targetLocaleID string) string {
+func localeURL(projectID, jobUID, targetLocaleID string) string {
 	return path.Join(jobBasePath, url.PathEscape(projectID), "jobs",
-		url.PathEscape(translationJobUID), "locales", url.PathEscape(targetLocaleID))
+		url.PathEscape(jobUID), "locales", url.PathEscape(targetLocaleID))
 }
 
-func requireParams(projectID, translationJobUID, targetLocaleID string) error {
+func requireParams(projectID, jobUID, targetLocaleID string) error {
 	switch {
 	case projectID == "":
 		return smerror.ErrEmptyParam("projectID")
-	case translationJobUID == "":
-		return smerror.ErrEmptyParam("translationJobUID")
+	case jobUID == "":
+		return smerror.ErrEmptyParam("jobUID")
 	case targetLocaleID == "":
 		return smerror.ErrEmptyParam("targetLocaleID")
 	}

--- a/api/job/locale/locale_test.go
+++ b/api/job/locale/locale_test.go
@@ -1,0 +1,140 @@
+package locale
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	smclient "github.com/Smartling/api-sdk-go/helpers/sm_client"
+	smerror "github.com/Smartling/api-sdk-go/helpers/sm_error"
+)
+
+func newTestJobLocale(t *testing.T, handler http.HandlerFunc) JobLocale {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := smclient.NewClient(server.Client(), "user", "secret")
+	client.BaseURL = server.URL
+	// Pre-populate a non-expiring access token so requests skip the live
+	// /auth-api/v2/authenticate handshake.
+	client.Credentials.AccessToken = &smclient.Token{
+		Value:          "fake-test-token",
+		ExpirationTime: time.Now().Add(1 * time.Hour),
+	}
+
+	return NewJobLocale(client)
+}
+
+func okEnvelope(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"response":{"code":"SUCCESS","data":null}}`))
+}
+
+func TestAdd_PostsToLocalePath(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/projects/p1/jobs/job-1/locales/fr-FR") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		okEnvelope(w)
+	}
+
+	jl := newTestJobLocale(t, handler)
+
+	if err := jl.Add(context.Background(), "p1", "job-1", "fr-FR"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRemove_DeletesLocalePath(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/projects/p1/jobs/job-1/locales/fr-FR") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		okEnvelope(w)
+	}
+
+	jl := newTestJobLocale(t, handler)
+
+	if err := jl.Remove(context.Background(), "p1", "job-1", "fr-FR"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAddRemove_EmptyParamsRejectedBeforeRequest(t *testing.T) {
+	called := false
+	jl := newTestJobLocale(t, func(http.ResponseWriter, *http.Request) { called = true })
+
+	cases := []struct {
+		name                            string
+		projectID, jobUID, targetLocale string
+	}{
+		{"empty project", "", "job-1", "fr-FR"},
+		{"empty job", "p1", "", "fr-FR"},
+		{"empty locale", "p1", "job-1", ""},
+	}
+	for _, c := range cases {
+		t.Run("add/"+c.name, func(t *testing.T) {
+			err := jl.Add(context.Background(), c.projectID, c.jobUID, c.targetLocale)
+			if !smerror.IsErrEmptyParam(err) {
+				t.Errorf("Add err = %v, want empty-param error", err)
+			}
+		})
+		t.Run("remove/"+c.name, func(t *testing.T) {
+			err := jl.Remove(context.Background(), c.projectID, c.jobUID, c.targetLocale)
+			if !smerror.IsErrEmptyParam(err) {
+				t.Errorf("Remove err = %v, want empty-param error", err)
+			}
+		})
+	}
+
+	if called {
+		t.Error("server was called despite empty-param validation")
+	}
+}
+
+func TestAdd_NotFoundIsWrapped(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"response":{"code":"NOT_FOUND","data":null}}`))
+	}
+
+	jl := newTestJobLocale(t, handler)
+
+	err := jl.Add(context.Background(), "p1", "job-1", "fr-FR")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to add locale to job") {
+		t.Errorf("err = %v, want wrapped %q", err, "failed to add locale to job")
+	}
+}
+
+func TestRemove_ServerErrorIsWrapped(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"response":{"code":"GENERAL_ERROR"}}`))
+	}
+
+	jl := newTestJobLocale(t, handler)
+
+	err := jl.Remove(context.Background(), "p1", "job-1", "fr-FR")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to remove locale from job") {
+		t.Errorf("err = %v, want wrapped %q", err, "failed to remove locale from job")
+	}
+}

--- a/helpers/sm_client/client_request.go
+++ b/helpers/sm_client/client_request.go
@@ -74,6 +74,17 @@ func (c *Client) GetJSON(
 	return c.requestJSON(ctx, "GET", url, params, nil, result, options...)
 }
 
+// DeleteJSON performs DELETE request to the Smartling API and tries to decode
+// the answer as JSON.
+func (c *Client) DeleteJSON(
+	ctx context.Context,
+	url string,
+	result any,
+	options ...any,
+) (json.RawMessage, int, error) {
+	return c.requestJSON(ctx, "DELETE", url, nil, nil, result, options...)
+}
+
 // Get performs raw GET request to the Smartling API. You probably do not want
 // to use it.
 func (c *Client) Get(


### PR DESCRIPTION
Added support for managing target locales on a translation job

- New `api/job/locale` package with a `JobLocale` interface:
  - `Add(...)` → POST /jobs-api/v3/projects/{projectId}/jobs/{jobUid}/locales/{localeId}
  - `Remove(...)` → DELETE on the same path
  - Required-param guards return `smerror.ErrEmptyParam`; transport errors wrapped with context.
- New `smclient.DeleteJSON` helper (mirrors `PostJSON/GetJSON`) for DELETE requests.

https://github.com/Smartling/smartling-cli/pull/110